### PR TITLE
More Responsive buttons --> immediately load static.gif when changing videos/channels

### DIFF
--- a/assets/js/youtube.js
+++ b/assets/js/youtube.js
@@ -44,6 +44,8 @@ function playListButtonListener(){
   currentVideoIndex = 0;
   //0.75)Immediately remove the current src file --> so static plays
   // $("#backgroundVideo").removeAttr("src");
+  $("#backgroundVideo").removeAttr("autoplay");
+  document.querySelector("#backgroundVideo").load();
   // 1. get the playlist id of the button clicked
   var playlist_id = $(this).data("id");
   var playlist_title = $(this).data("playlist");
@@ -56,8 +58,9 @@ function playListButtonListener(){
 function playNext(){
   // 0. Immediately remove the current src file --> so static plays
     // $("#backgroundVideo").removeAttr("src");
-    document.querySelector("#backgroundVideo").load();
+    // document.querySelector("#backgroundVideo").load();
     $("#backgroundVideo").removeAttr("autoplay");
+    document.querySelector("#backgroundVideo").load();
     // debugger;
     // debugger;
   // console.log(this);
@@ -156,7 +159,7 @@ function playVideo(url){
   // change the video src to load the new video
   $("#backgroundVideo").attr("src", url);
   // turn autoplay back on
-  $("#backgroundVideo").attr("autoplay", true);
+  $("#backgroundVideo").prop("autoplay", true);
   // debugger;
   document.querySelector("#backgroundVideo").load();
   var video = videos_array[currentVideoIndex];

--- a/assets/js/youtube.js
+++ b/assets/js/youtube.js
@@ -38,9 +38,12 @@ function playListButtonListener(){
     $(".active-btn").removeClass("active-btn");
     $(this).addClass("active-btn");
     $(".channel-toggle").trigger("click");
-    $('.video-info').html('NOW WATCHING: ' + $(this).html());
+    // console.info(this);
+    // debugger;
   // 0.5) reset the currentVideoIndex to zero & empty the array;
   currentVideoIndex = 0;
+  //0.75)Immediately remove the current src file --> so static plays
+  // $("#backgroundVideo").removeAttr("src");
   // 1. get the playlist id of the button clicked
   var playlist_id = $(this).data("id");
   var playlist_title = $(this).data("playlist");
@@ -51,6 +54,12 @@ function playListButtonListener(){
 
 // Event Listener - when video ends
 function playNext(){
+  // 0. Immediately remove the current src file --> so static plays
+    // $("#backgroundVideo").removeAttr("src");
+    document.querySelector("#backgroundVideo").load();
+    $("#backgroundVideo").removeAttr("autoplay");
+    // debugger;
+    // debugger;
   // console.log(this);
   // console.log(currentVideoIndex);
   currentVideoIndex ++;
@@ -144,12 +153,29 @@ function getMp4file(videoID){
 
 // ----------- #3 playVideo()----------
 function playVideo(url){
-  // console.info(mp4_url);
-  // $("source").attr("src", url);
-  // $("video")[0].load();
-  // var test = $("#backgroundVideo");
+  // change the video src to load the new video
   $("#backgroundVideo").attr("src", url);
-  // $("#backgroundVideo").load();
+  // turn autoplay back on
+  $("#backgroundVideo").attr("autoplay", true);
+  // debugger;
+  document.querySelector("#backgroundVideo").load();
+  var video = videos_array[currentVideoIndex];
+  var current_playlist = video["playlist"];
+  // DEVELOPMENT - testing code below:
+  console.info("Current Video Information");
+  console.info(video);
+  console.info("--------------------------");
+  // update the video info & highlight playlist
+  $('.video-info').html('NOW WATCHING: ' + video.title);
+  $(".active-btn").removeClass("active-btn");
+  // Get all the playlist buttons & check which one has a matching name
+  var playlist_btn_array = document.querySelectorAll(".playlist-btn");
+  Object.keys(playlist_btn_array).forEach(function(index){
+    if ($(playlist_btn_array[index]).data("playlist") == current_playlist){
+      // console.log(playlist_btn_array[index]);
+      $(playlist_btn_array[index]).addClass("active-btn");
+    }
+  });
 }
 
 // ---------------------- END: YOUTUBE API -----------------------------------


### PR DESCRIPTION
- In the eventListener functions ("playListButtonListener" & "playNext"), I remove the autoplay feature of the video & reload it so it essentially plays just the poster image which is the gif.

- Then when the new video is loaded in the function ("playVideo") I reset the autoplay property & give it a new url source

- Feel free to test it out more!