### PR TITLE
403 error on loading the video src

### DIFF
--- a/assets/js/youtube.js
+++ b/assets/js/youtube.js
@@ -210,4 +210,10 @@ $(document).ready(function(){
   // 5. Default just play videos from nature?
   // COMMENT OUT LATER
   getVideos_fromPlaylist("PLYPNYHaAOM8ncN-jTgNY25aFAYeMOQl9C", "North Lights");
+
+  // 6. catch video errors
+  $("video").on("error", function(){
+    console.warn("VIDEO CAN'T BE PLAYED");
+    playNext();
+  })
 }); // closes document.ready


### PR DESCRIPTION
The simplest way to fix the GET request error. It will still end up printing in console. But using the "error" event, we can just tell it to play the next video